### PR TITLE
Added support for server-side rendering

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,8 +37,9 @@ const _options = {
  * @param {_options} [options] - options
  * @param {boolean} [autofill=false] - an option to fill all empty properties with 'no prefix'
  * @param {boolean} [override=false] - an option to override default options and add custom tags
+ * @param {document} [document=document] - an option to override the global document and use another document object
  */
-function addCards(options, autofill = false, override = false) {
+function addCards(options, autofill = false, override = false, document = document) {
   const head = document.head || document.getElementsByTagName('head')[0];
   const parsedOptions = _parseOptions(options, autofill, override);
   Object.keys(parsedOptions).forEach((prop) => {

--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@ const _options = {
  * @param {boolean} [autofill=false] - an option to fill all empty properties with 'no prefix'
  * @param {boolean} [override=false] - an option to override default options and add custom tags
  * @param {document} [document=document] - an option to override the global document and use another document object
+ * @return {string} HTML - a string of the html of all the created meta-tags
  */
 function addCards(options, autofill = false, override = false, document = document) {
   const head = document.head || document.getElementsByTagName('head')[0];

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ function addCards(options, autofill = false, override = false, document = docume
     );
     metaTag.content = content;
     head.appendChild(metaTag);
-    return mateTag.outerHTML;
+    return metaTag.outerHTML;
   }).join('');
 }
 

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ const _options = {
 function addCards(options, autofill = false, override = false, document = document) {
   const head = document.head || document.getElementsByTagName('head')[0];
   const parsedOptions = _parseOptions(options, autofill, override);
-  Object.keys(parsedOptions).forEach((prop) => {
+  return Object.keys(parsedOptions).map((prop) => {
     const content = parsedOptions[prop];
     if (!content) return;
     const metaTag = document.createElement('meta');
@@ -52,7 +52,8 @@ function addCards(options, autofill = false, override = false, document = docume
     );
     metaTag.content = content;
     head.appendChild(metaTag);
-  });
+    return mateTag.outerHTML;
+  }).join('');
 }
 
 /**


### PR DESCRIPTION
By allowing usage of other documents than the global one and returning the HTML string, this package can more easily be used for server-side rendering in Node.js where there is no initial document